### PR TITLE
Fixed lack of initialization causing max/min values below/above zero …

### DIFF
--- a/examples/calibration/calibration.ino
+++ b/examples/calibration/calibration.ino
@@ -1,13 +1,13 @@
 #include <Wire.h>
 #include <Adafruit_Sensor.h>
 #include <Adafruit_LIS2MDL.h>
-
+#include <float.h>
 
 Adafruit_LIS2MDL mag = Adafruit_LIS2MDL(12345);
 
-float MagMinX, MagMaxX;
-float MagMinY, MagMaxY;
-float MagMinZ, MagMaxZ;
+float MagMinX = FLT_MAX, MagMaxX = FLT_MIN;
+float MagMinY = FLT_MAX, MagMaxY = FLT_MIN;
+float MagMinZ = FLT_MAX, MagMaxZ = FLT_MIN;
 
 long lastDisplayTime;
 


### PR DESCRIPTION
…respectively to be missed

Adds initialization of the minimum and max values for each channel to FLT_MAX and FLT_MIN respectively, from float.h. Without this change, if the correct maximum value is below zero or the minimum is above zero, the output will erroneously read zero.
