### PR TITLE
Fix repeated memory allocations

### DIFF
--- a/Adafruit_LIS2MDL.cpp
+++ b/Adafruit_LIS2MDL.cpp
@@ -173,6 +173,7 @@ bool Adafruit_LIS2MDL::_init(void) {
     return false;
   }
 
+  if (config_a) delete config_a; 
   config_a = new Adafruit_BusIO_Register(i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD,
                                          LIS2MDL_CFG_REG_A, 1);
 

--- a/Adafruit_LIS2MDL.cpp
+++ b/Adafruit_LIS2MDL.cpp
@@ -172,9 +172,9 @@ bool Adafruit_LIS2MDL::_init(void) {
     // No LIS2MDL detected ... return false
     return false;
   }
- 
+
   if (config_a)
-    delete config_a; 
+    delete config_a;
   config_a = new Adafruit_BusIO_Register(i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD,
                                          LIS2MDL_CFG_REG_A, 1);
 

--- a/Adafruit_LIS2MDL.cpp
+++ b/Adafruit_LIS2MDL.cpp
@@ -172,8 +172,9 @@ bool Adafruit_LIS2MDL::_init(void) {
     // No LIS2MDL detected ... return false
     return false;
   }
-
-  if (config_a) delete config_a; 
+ 
+  if (config_a)
+    delete config_a; 
   config_a = new Adafruit_BusIO_Register(i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD,
                                          LIS2MDL_CFG_REG_A, 1);
 


### PR DESCRIPTION
Hi folks,

This minor pull request fixes the issue identified in https://github.com/adafruit/Adafruit_LIS2MDL/issues/11, where repeated sensor initialization after power off/on would result in new memory allocations and eventually cause the stack to crash.

After a brief investigation, this memory leak was caused by `config_a` being repeatedly allocated and never deleted. A simple if statement to first check for and then delete `config_a` did the trick. The library was tested with this change and it is confirmed the available free RAM on a SAMD21-based Adafruit microcontroller remained constant throughout several dozen reinitializations.

Cheers,
Adam