### PR TITLE
Set config_a to NULL in Adafruit_LIS2MDL.h

### DIFF
--- a/Adafruit_LIS2MDL.h
+++ b/Adafruit_LIS2MDL.h
@@ -114,7 +114,7 @@ private:
   bool _init(void);
 
   int32_t _sensorID;
-  Adafruit_BusIO_Register *config_a;
+  Adafruit_BusIO_Register *config_a = NULL;
 
   void read(void);
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit LIS2MDL
-version=2.1.8
+version=2.1.9
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Unified Magnetometer sensor driver for Adafruit's LIS2MDL Breakout


### PR DESCRIPTION
Initialize config_a to NULL in the Adafruit_LIS2MDL class.
